### PR TITLE
ADD: support for system-wide dirs

### DIFF
--- a/protonsh.sh
+++ b/protonsh.sh
@@ -98,15 +98,21 @@ else
 	die "Not a valid prefix choice! ($CHOICE)"
 fi
 
+shopt -s nullglob
 echo "List of proton versions installed in Steam:"
 I=0
-for PROTON_VERSION in "$STEAM_APPS_DIR"/common/Proton*
+for PROTON_VERSION in \
+	"$STEAM_APPS_DIR"/common/Proton* \
+	/usr/share/steam/compatibilitytools.d/* \
+	/usr/local/share/steam/compatibilitytools.d/* \
+	"$HOME"/.steam/root/compatibilitytools.d/*
 do
 	PROTON_VERSIONS[$I]="$PROTON_VERSION"
 	versionName="${PROTON_VERSION##*/}"
 	echo "$I) $versionName"
 	I=$((I+1))
 done
+shopt -u nullglob
 echo -n "Choice? "
 read -r CHOICE
 if get_menu_choice "$CHOICE" 0 "$I"

--- a/protonsh.sh
+++ b/protonsh.sh
@@ -46,8 +46,8 @@ override_p()
 }
 
 # $1: user input
-# $2: choice min
-# $3: choice max
+# $2: choice min (inclusive)
+# $3: choice max (exclusive)
 get_menu_choice()
 {
 	local input min max
@@ -60,7 +60,7 @@ get_menu_choice()
 			return 1
 			;;
 		*)
-			if [ "$input" -ge "$min" ] && [ "$input" -le "$max" ]
+			if [ "$input" -ge "$min" ] && [ "$input" -lt "$max" ]
 			then
 				export menu_choice="$input"
 				return 0

--- a/protonsh.sh
+++ b/protonsh.sh
@@ -91,11 +91,11 @@ search_compat_tools()
 	then
 		declare -a extraLocs appendLocs
 		IFS=':' read -r -a extraLocs <<< "$STEAM_EXTRA_COMPAT_TOOLS_PATHS"
-		for ((i=0; i<${#extraLocs[*]}; i++))
+		for loc in "${extraLocs[@]}"
 		do
-			if compgen -G "${extraLocs[i]}/*"
+			if compgen -G "$loc/*"
 			then
-				appendLocs+=( "${extraLocs[i]}"/* )
+				appendLocs+=( "$loc"/* )
 			fi
 		done
 		if [ "${#appendLocs[*]}" -gt 0 ]


### PR DESCRIPTION
Closes #2

Steam compatibilitytools.d directories can be found in a number of places